### PR TITLE
Add logger via plenary

### DIFF
--- a/lua/tempgen/init.lua
+++ b/lua/tempgen/init.lua
@@ -1,8 +1,14 @@
 local M = {}
 
+local log = require("tempgen.log")
+
 function M.setup(opts)
-	opts = opts or {}
-	print("executing tempgen setup")
+	if opts == nil or opts.path == nil then
+		log.warn("User path for templates are not specified in config. Therefore, the plugin setup is skipped.") -- log warning to user.
+		return
+	end
+
+	print(opts.path)
 end
 
 return M

--- a/lua/tempgen/log.lua
+++ b/lua/tempgen/log.lua
@@ -1,0 +1,4 @@
+return require("plenary.log").new({
+	plugin = "tempgen",
+	level = "info",
+})

--- a/plugin/tempgen.lua
+++ b/plugin/tempgen.lua
@@ -1,3 +1,3 @@
 if vim.fn.has("nvim-0.7.0") ~= 1 then
-	vim.api.nvim_err_writeln("Hardtime.nvim requires at least nvim-0.7.0.")
+	vim.api.nvim_err_writeln("tempgen.nvim requires at least nvim-0.7.0.")
 end


### PR DESCRIPTION
A basic logger is added to the plugin to:

- Notify the user if an input is missing,
- Debug the plugin during development and when using.

`plenary.nvim`'s `log` is added to the project. This makes `plenary.nvim` a dependency of this plugin.
Since this plugin will use `telescope.nvim`, it will contain `plenary.nvim` anyway, therefore there is no significant tradeoff here.

The logger is used during `setup` as an example.
In this case, when the user does not specify their template path, the plugin setup is skipped. Therefore, a log is added to warn them about the plugin usage.