### PR TITLE
Implement template generation

### DIFF
--- a/lua/.luarc.json
+++ b/lua/.luarc.json
@@ -1,0 +1,5 @@
+{
+    "diagnostics.globals": [
+        "vim"
+    ]
+}

--- a/lua/tempgen/init.lua
+++ b/lua/tempgen/init.lua
@@ -9,10 +9,47 @@ local telescope_builtin = require("telescope.builtin")
 local telescope_actions = require("telescope.actions")
 local telescope_actions_state = require("telescope.actions.state")
 local telescope_utils = require("telescope.utils")
+
 local config = {}
 
 local function setTemplatePath(path)
-	config.path = path
+	local trailing_slash = string.sub(path, #path)
+	if trailing_slash == "/" or trailing_slash == "\\" then
+		path = string.sub(path, 1, #path - 1)
+	end
+
+	config.path = telescope_utils.path_expand(path)
+end
+
+local function setUserCommand()
+	local copy_template = function(prompt_bufnr)
+		local selected_entry = telescope_actions_state.get_selected_entry()
+		local selected_file = selected_entry[1]
+
+		telescope_actions.close(prompt_bufnr)
+
+		local template_path = config.path .. "/" .. selected_file
+		local buffer_path = vim.api.nvim_buf_get_name(0)
+
+		vim.system({ "cp", template_path, buffer_path }):wait()
+		vim.cmd("e!")
+	end
+
+	vim.api.nvim_create_user_command("Tempgen", function()
+		local filetype = vim.bo.filetype
+
+		telescope_builtin.find_files({
+			cwd = config.path,
+			find_command = { "fd", "--type", "f", "--extension", filetype },
+			prompt_title = "Find Template",
+			preview_title = "Template Preview",
+			attach_mappings = function(_, map)
+				map("n", "<CR>", copy_template)
+				map("i", "<CR>", copy_template)
+				return true
+			end,
+		})
+	end, {})
 end
 
 function M.setup(opts)
@@ -21,11 +58,12 @@ function M.setup(opts)
 		return
 	end
 
-	setTemplatePath(opts.path)
-end
+	if type(opts.path) ~= "string" then
+		log.warn("Only string paths are supported in config. Therefore, the plugin setup is skipped")
+	end
 
-vim.api.nvim_create_user_command("Tempgen", function()
-	print("exec tempgen")
-end, {})
+	setTemplatePath(opts.path)
+	setUserCommand()
+end
 
 return M

--- a/lua/tempgen/init.lua
+++ b/lua/tempgen/init.lua
@@ -1,14 +1,31 @@
 local M = {}
 
-local log = require("tempgen.log")
+local log = require("plenary.log").new({
+	plugin = "tempgen",
+	level = "info",
+})
+
+local telescope_builtin = require("telescope.builtin")
+local telescope_actions = require("telescope.actions")
+local telescope_actions_state = require("telescope.actions.state")
+local telescope_utils = require("telescope.utils")
+local config = {}
+
+local function setTemplatePath(path)
+	config.path = path
+end
 
 function M.setup(opts)
 	if opts == nil or opts.path == nil then
-		log.warn("User path for templates are not specified in config. Therefore, the plugin setup is skipped.") -- log warning to user.
+		log.warn("User path for templates are not specified in config. Therefore, the plugin setup is skipped.")
 		return
 	end
 
-	print(opts.path)
+	setTemplatePath(opts.path)
 end
+
+vim.api.nvim_create_user_command("Tempgen", function()
+	print("exec tempgen")
+end, {})
 
 return M

--- a/lua/tempgen/log.lua
+++ b/lua/tempgen/log.lua
@@ -1,4 +1,0 @@
-return require("plenary.log").new({
-	plugin = "tempgen",
-	level = "info",
-})


### PR DESCRIPTION
`telescope.find_files` is used to open a telescope window to the user, allowing them to search their templates in their path.

Also, a custom function is added to `<CR>` mapping to trigger the actual template generation when user selects a file.
The template generation is quite simple, it just takes the selected file, and the current buffer and executes a `cp` command.

Several small changes are also made in this branch:

- To disable the diagnostics for global variables, a `luarc.json` file is added.
- Since the plugin itself is quite basic, I removed `log.lua` file and decided to put it in `init.lua`.

There is no need to apply an extensible modular system to the plugin for now, given that the size of the plugin is quite small and I would like to go for that solution if multiple modules are absolutely necessary.